### PR TITLE
Ignore events where the event description contains the string "ignore break-time"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 *   Add a window title check for Zoom calls.
     [#17](https://github.com/cdepillabout/break-time/pull/17)
 
+*   For the Google Calendar plugin, ignore events from consideration where the
+    event description contains the string ignore break-time.  This gives a nice
+    way to make sure that break-time continues to force breaks to occur even if
+    you have an event on your google calendar.
+    [#19](https://github.com/cdepillabout/break-time/pull/19)
+
 ## 0.1.2
 
 *   Add a window title check for Slack calls.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ break-time from starting a break.
 This is convenient to stop a break from happening when you're in a meeting at
 work.
 
+This plugin has a feature where if your Google Calendar event has a description
+with the magic string `ignore break-time`, break-time will ignore it when
+considering whether or not to start a break.
+
 This plugin requires some configuration before it can be used.  First, you must
 add your Gmail address to the break-time configuration file,
 `~/.config/break-time/config.toml`.  The `accounts` (or

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -331,16 +331,32 @@ fn has_event(
             match events.items {
                 None => Ok(HasEvent::No),
                 Some(event_items) => {
-                    if event_items.is_empty() {
+                    let filtered_events = filter_cal_events(event_items);
+                    if filtered_events.is_empty() {
                         Ok(HasEvent::No)
                     } else {
-                        println!("There were some event items from calendar id {}: {:?}", calendar_id, event_items);
+                        println!("There were some event items from calendar id {}: {:?}", calendar_id, filtered_events);
                         Ok(HasEvent::Yes)
                     }
                 }
             }
         }
     }
+}
+
+fn filter_cal_events(events: Vec<google_calendar3::Event>) -> Vec<google_calendar3::Event> {
+    events.into_iter().filter(filter_event).collect()
+}
+
+fn filter_event(event: &google_calendar3::Event) -> bool {
+    if let Some(desc) = &event.description {
+        if desc.to_lowercase().contains("ignore break-time") {
+            // println!("filtering out event because description ignores break-time: {:?}", event);
+            return false;
+        }
+    }
+
+    true
 }
 
 impl Plugin for GoogleCalendar {

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -344,7 +344,9 @@ fn has_event(
     }
 }
 
-fn filter_cal_events(events: Vec<google_calendar3::Event>) -> Vec<google_calendar3::Event> {
+fn filter_cal_events(
+    events: Vec<google_calendar3::Event>,
+) -> Vec<google_calendar3::Event> {
     events.into_iter().filter(filter_event).collect()
 }
 


### PR DESCRIPTION
For the Google Calendar plugin, ignore events from consideration where the event description contains the string `ignore break-time`.

This gives a nice way to make sure that break-time continues to force breaks to occur even if you have an event on your google calendar.