### PR TITLE
Ignore events where the status is "cancelled"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@
     [#17](https://github.com/cdepillabout/break-time/pull/17)
 
 *   For the Google Calendar plugin, ignore events from consideration where the
-    event description contains the string ignore break-time.  This gives a nice
-    way to make sure that break-time continues to force breaks to occur even if
-    you have an event on your google calendar.
+    event description contains the string `ignore break-time`.  This gives a
+    nice way to make sure that break-time continues to force breaks to occur
+    even if you have an event on your google calendar.
     [#19](https://github.com/cdepillabout/break-time/pull/19)
+
+*   For the Google Calendar plugin, ignores events where the status is
+    `cancelled`.  For some reason, sometimes events that become cancelled still
+    show up on your calendar and in responses from the Google Calendar APIs.
+    [#20](https://github.com/cdepillabout/break-time/pull/20)
 
 ## 0.1.2
 

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -351,9 +351,18 @@ fn filter_cal_events(
 }
 
 fn filter_event(event: &google_calendar3::Event) -> bool {
+    // Ignore events where the description contains the magic string
+    // "ignore break-time"
     if let Some(desc) = &event.description {
         if desc.to_lowercase().contains("ignore break-time") {
             // println!("filtering out event because description ignores break-time: {:?}", event);
+            return false;
+        }
+    }
+
+    // Ignore events where the status is "cancelled"
+    if let Some(status) = &event.status {
+        if status == "cancelled" {
             return false;
         }
     }


### PR DESCRIPTION
For the Google Calendar plugin, this PR ignores events where the status is `cancelled`.

For some reason, sometimes events that become `cancelled` still show up on your calendar.