### PR TITLE
Ignore events where you are marked as not attending

### DIFF
--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -351,11 +351,17 @@ fn filter_cal_events(
 }
 
 fn filter_event(event: &google_calendar3::Event) -> bool {
-    // Ignore events where the description contains the magic string
-    // "ignore break-time"
     if let Some(desc) = &event.description {
+        // Ignore events where the description contains the magic string
+        // "ignore break-time"
         if desc.to_lowercase().contains("ignore break-time") {
-            // println!("filtering out event because description ignores break-time: {:?}", event);
+            return false;
+        }
+
+        // Ignore events where the description talks about being an out-of-office event.
+        // Even if we are out-of-office, we still may be on our personal computer, and
+        // want break-time to occassionally break.
+        if desc.to_lowercase().contains("out-of-office event") {
             return false;
         }
     }

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -367,6 +367,15 @@ fn filter_event(event: &google_calendar3::Event) -> bool {
         }
     }
 
+    // Ignore events where there are attendees, and you are marked as not attending.
+    if let Some(attendees) = &event.attendees {
+        if let Some(me) = attendees.iter().find(|attendee| attendee.self_ == Some(true)) {
+            if me.response_status == Some(String::from("declined")) {
+                return false;
+            }
+        }
+    }
+
     true
 }
 

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -375,7 +375,10 @@ fn filter_event(event: &google_calendar3::Event) -> bool {
 
     // Ignore events where there are attendees, and you are marked as not attending.
     if let Some(attendees) = &event.attendees {
-        if let Some(me) = attendees.iter().find(|attendee| attendee.self_ == Some(true)) {
+        if let Some(me) = attendees
+            .iter()
+            .find(|attendee| attendee.self_ == Some(true))
+        {
             if me.response_status == Some(String::from("declined")) {
                 return false;
             }


### PR DESCRIPTION
This PR adds a feature where Google Calendar events will be ignored when you are marked as not attending.  This means that break-time will still pop up a break even when you are in a scheduled event, as long as you are marked as not attending that event.