### PR TITLE
prevent breaks occuring during repeated event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
     where the status is `needsAction`.
     [#22](https://github.com/cdepillabout/break-time/pull/22)
 
+*   For the Google Calendar plugin, treat all events as single events (instead of
+    treating repeated events specially).  This fixes a bug with handling of
+    repeated events.  Sometimes the Google Calendar API would return repeated
+    events in times when it doesn't make sense, but this PR fixes this.
+    [#23](https://github.com/cdepillabout/break-time/pull/23)
+
 ## 0.1.2
 
 *   Add a window title check for Slack calls.

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -319,6 +319,8 @@ fn has_event(
         // all events that occur over the next 20 minutes
         .time_min(&start_time.to_rfc3339())
         .time_max(&end_time.to_rfc3339())
+        // Expand recurring events into single events.
+        .single_events(true)
         .doit();
 
     // println!("\n\nevents for {}: {:?}", calendar_id, result);

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -242,6 +242,7 @@ fn get_all_calendar_ids(hub: &CalHub) -> Vec<String> {
     calendar_ids
 }
 
+/// Check whether or not any events occur during the `start_time` to `end_time`.
 fn has_events(
     email: &str,
     hub: &CalHub,

--- a/src/scheduler/plugins/google_calendar.rs
+++ b/src/scheduler/plugins/google_calendar.rs
@@ -332,7 +332,7 @@ fn has_event(
             match events.items {
                 None => Ok(HasEvent::No),
                 Some(event_items) => {
-                    let filtered_events = filter_cal_events(event_items);
+                    let filtered_events = filter_cal_events(event_items, start_time, end_time);
                     if filtered_events.is_empty() {
                         Ok(HasEvent::No)
                     } else {
@@ -347,11 +347,13 @@ fn has_event(
 
 fn filter_cal_events(
     events: Vec<google_calendar3::Event>,
+    start_time: chrono::DateTime<chrono::Utc>,
+    end_time: chrono::DateTime<chrono::Utc>,
 ) -> Vec<google_calendar3::Event> {
-    events.into_iter().filter(filter_event).collect()
+    events.into_iter().filter(|event| filter_event(event, start_time, end_time)).collect()
 }
 
-fn filter_event(event: &google_calendar3::Event) -> bool {
+fn filter_event(event: &google_calendar3::Event, start_time: chrono::DateTime<chrono::Utc>, end_time: chrono::DateTime<chrono::Utc>) -> bool {
     if let Some(desc) = &event.description {
         // Ignore events where the description contains the magic string
         // "ignore break-time"
@@ -390,8 +392,38 @@ fn filter_event(event: &google_calendar3::Event) -> bool {
         }
     }
 
+    println!("About to check event start and end time, event: {:?}", event);
+
+    // Ignore events where the event end time is not after our beginning search timespan, and the event
+    // beginning time is not before our ending search timespan.
+    //
+    // When you move weekly repeated events around your calendar, sometimes Google Calendar will get
+    // confused and show an event that has been moved to another day.  The `event.start` and
+    // `event.end` times are set correctly, so we have to check to make sure that the event
+    // actually falls within the time range we are looking for events.
+    if let Some(event_start) = event.start.as_ref().and_then(event_date_time_to_date_time) {
+        if let Some(event_end) = event.end.as_ref().and_then(event_date_time_to_date_time) {
+            if event_start > end_time || event_end < start_time {
+                return false;
+            }
+        }
+    }
+
     true
 }
+
+fn event_date_time_to_date_time(event_date_time: &google_calendar3::EventDateTime) -> Option<chrono::DateTime<chrono::Utc>> {
+    match &event_date_time.date_time {
+        None => None,
+        Some(date_time_str) => {
+            chrono::DateTime::parse_from_rfc3339(date_time_str)
+                .map(|date_time| date_time.with_timezone(&chrono::Utc))
+                .ok()
+        }
+    }
+}
+
+
 
 impl Plugin for GoogleCalendar {
     fn can_break_now(&self) -> Result<CanBreak, Box<dyn std::error::Error>> {


### PR DESCRIPTION
There was some problem with breaks being prevented from a reoccuring event that was moved to another date.

This fixes #14.