### PR TITLE
Option for ignoring idle timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 *   Add a window title check for Zoom calls.
     [#17](https://github.com/cdepillabout/break-time/pull/17)
 
+*   Add a window title check for Skype, Jitsi, and BigBlueButton.
+    [#17](https://github.com/cdepillabout/break-time/pull/17)
+
 *   For the Google Calendar plugin, ignore events from consideration where the
     event description contains the string `ignore break-time`.  This gives a
     nice way to make sure that break-time continues to force breaks to occur
@@ -29,6 +32,7 @@
 
 *   Add two command line commands: `google-calendar list-events` and
     `google-calendar ignore-event`.
+    [#25](https://github.com/cdepillabout/break-time/pull/25)
 
     `google-calendar list-events` lists all the Google Calendar events that are
     occurring right now that will cause break-time to ignore a scheduled break
@@ -47,6 +51,11 @@
     ```console
     $ break-time google-calendar ignore-event "123phhhlpppoohh88hhcl9988b"
     ```
+
+*   Add a value to the config file `idle_detection_enabled`.  It is set to
+    `true` by default.  If you set it to false, then the X idle timer is
+    ignored, so breaks will still occur even if you have stepped away from your
+    computer. [#31](https://github.com/cdepillabout/break-time/pull/31)
 
 ## 0.1.2
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ early.  Once a break starts, you are forced to stop using your computer.
 However, there are plugins provided to avoid breaks at inconvenient times.  For
 instance, there is a plugin to avoid having a break occur during a time when
 you have an event on your Google Calendar, as well as a plugin to avoid a break
-when you are on a video chat in Google Meet.
+when you are on a video chat in Google Meet, Zoom, etc.
 
 break-time currently only runs on Linux with X11.  However, PRs are welcome
 adding support for other platforms and window systems.

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,8 @@ pub struct Settings {
     pub seconds_between_breaks: u32,
     #[serde(default = "default_clicks_to_end_break_early")]
     pub clicks_to_end_break_early: u32,
+    #[serde(default = "default_idle_detection_enabled")]
+    pub idle_detection_enabled: bool,
     #[serde(default = "default_idle_detection_seconds")]
     pub idle_detection_seconds: u32,
     #[serde(rename = "plugin")]
@@ -67,6 +69,10 @@ const fn default_clicks_to_end_break_early() -> u32 {
     400
 }
 
+const fn default_idle_detection_enabled() -> bool {
+    true
+}
+
 const fn default_idle_detection_seconds() -> u32 {
     480
 }
@@ -78,6 +84,7 @@ impl Default for Settings {
             seconds_between_breaks: default_seconds_between_breaks(),
             clicks_to_end_break_early: default_clicks_to_end_break_early(),
             all_plugin_settings: PluginSettings::default(),
+            idle_detection_enabled: default_idle_detection_enabled(),
             idle_detection_seconds: default_idle_detection_seconds(),
         }
     }

--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -8,6 +8,17 @@ pub const DEFAULT_CONFIG_SETTINGS: &str = indoc!(
     # The number of seconds in between breaks.
     seconds_between_breaks = 3000 # 50 minutes
 
+    # Whether or not to use idle detection.
+    #
+    # If set to true (the default), break-time will watch X events.  If it detects you
+    # haven't typed on the keyboard or used the mouse for `idle_detection_seconds`, it
+    # will use this time as a break, and then set the next break to occur in
+    # `seconds_between_breaks`.
+    #
+    # If set to false, break-time will ignore any X idle time and just start a new break
+    # every `seconds_between_breaks`.
+    idle_detection_enabled = true
+
     # The number of seconds to use for a break if you've been idle. This
     # means that if break-time detects that you've been idle for 8 minutes,
     # it will use that time as a break.  It will then start waiting for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub enum Msg {
     Resume,
     StartBreak,
     TimeRemainingBeforeBreak(Duration),
+    EnableIdleDetector,
+    DisableIdleDetector,
 }
 
 fn handle_msg_recv(
@@ -70,6 +72,14 @@ fn handle_msg_recv(
         Msg::TimeRemainingBeforeBreak(remaining_time) => {
             tray.update_time_remaining(remaining_time);
         }
+        Msg::EnableIdleDetector => {
+            tray.set_is_idle_detector_enabled(tray::IsIdleDetectorEnabled::Yes);
+            scheduler_inner_sender.send(scheduler::InnerMsg::EnableIdleDetector).expect("TODO: figure out what to do about channels potentially failing");
+        }
+        Msg::DisableIdleDetector => {
+            tray.set_is_idle_detector_enabled(tray::IsIdleDetectorEnabled::No);
+            scheduler_inner_sender.send(scheduler::InnerMsg::DisableIdleDetector).expect("TODO: figure out what to do about channels potentially failing");
+        }
     }
 }
 
@@ -79,7 +89,7 @@ pub fn run(config: Config) {
     let (sender, receiver) =
         glib::MainContext::channel(glib::source::PRIORITY_DEFAULT);
 
-    let mut tray = tray::Tray::run(sender.clone());
+    let mut tray = tray::Tray::run(&config, sender.clone());
 
     println!("Starting the scheduler...");
     let (scheduler_outer_sender, scheduler_inner_sender) =

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -93,7 +93,7 @@ enum WaitUntilBreakResult {
 
 impl Scheduler {
     pub fn new(
-        config: Config,
+        config: &Config,
         sender: glib::Sender<super::Msg>,
         break_ending_receiver: Receiver<Msg>,
         restart_wait_time_receiver: Receiver<InnerMsg>,
@@ -122,7 +122,7 @@ impl Scheduler {
         std::thread::spawn(move || {
             // TODO: Need to actually handle this error.
             let mut sched = Self::new(
-                config_clone,
+                &config_clone,
                 sender,
                 sched_break_ending_receiver,
                 restart_wait_time_receiver,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -277,7 +277,7 @@ pub enum InnerMsg {
     Pause,
     HasBeenIdle,
     EnableIdleDetector,
-    DisableIdleDetector
+    DisableIdleDetector,
 }
 
 fn create_periods_to_send_time_left_message(

--- a/src/scheduler/plugins/window_titles.rs
+++ b/src/scheduler/plugins/window_titles.rs
@@ -342,8 +342,10 @@ struct WinPropCookies<'a> {
 
 #[derive(Clone, Debug)]
 struct WinProps {
+    #[allow(dead_code)]
     wm_name: Result<String, ()>,
     net_wm_name: Result<String, ()>,
+    #[allow(dead_code)]
     transient_for_wins: Result<Vec<xcb::Window>, ()>,
     class_name: Result<String, ()>,
     class: Result<String, ()>,

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -269,8 +269,8 @@ impl Tray {
             signal_handler_disconnect(self.status_icon, prev_signal_handler_id);
         }
 
-        let is_idle_detector_enabled = self.is_idle_detector_enabled.clone();
-        let is_paused = self.is_paused.clone();
+        let is_idle_detector_enabled = self.is_idle_detector_enabled;
+        let is_paused = self.is_paused;
 
         let sender = self.sender.clone();
         let signal_handler_id = connect_popup_menu(

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -137,13 +137,12 @@ impl Tray {
 
         let menu_right_click_signal_handler_id = None;
 
-        let is_idle_detector_enabled =
-            if config.settings.idle_detection_enabled {
-                IsIdleDetectorEnabled::Yes
-            } else {
-                IsIdleDetectorEnabled::No
-            };
-
+        let is_idle_detector_enabled = if config.settings.idle_detection_enabled
+        {
+            IsIdleDetectorEnabled::Yes
+        } else {
+            IsIdleDetectorEnabled::No
+        };
 
         let tray = Self {
             status_icon,
@@ -257,7 +256,10 @@ impl Tray {
         self.render_normal_icon();
     }
 
-    pub fn set_is_idle_detector_enabled(&mut self, is_idle_detector_enabled: IsIdleDetectorEnabled) {
+    pub fn set_is_idle_detector_enabled(
+        &mut self,
+        is_idle_detector_enabled: IsIdleDetectorEnabled,
+    ) {
         self.is_idle_detector_enabled = is_idle_detector_enabled;
         self.conn_popup_menu();
     }
@@ -307,24 +309,32 @@ impl Tray {
                 match is_idle_detector_enabled {
                     IsIdleDetectorEnabled::No => {
                         let enable_idle_detector_item =
-                            gtk::MenuItem::new_with_label("Enable Idle Detector");
+                            gtk::MenuItem::new_with_label(
+                                "Enable Idle Detector",
+                            );
                         let sender_clone = sender.clone();
                         enable_idle_detector_item.connect_activate(move |_| {
-                            sender_clone
-                                .send(Msg::EnableIdleDetector)
-                                .expect("Could not send Msg::EnableIdleDetector");
+                            sender_clone.send(Msg::EnableIdleDetector).expect(
+                                "Could not send Msg::EnableIdleDetector",
+                            );
                         });
                         menu.append(&enable_idle_detector_item);
                     }
                     IsIdleDetectorEnabled::Yes => {
                         let disable_idle_detector_item =
-                            gtk::MenuItem::new_with_label("Disable Idle Detector");
+                            gtk::MenuItem::new_with_label(
+                                "Disable Idle Detector",
+                            );
                         let sender_clone = sender.clone();
-                        disable_idle_detector_item.connect_activate(move |_| {
-                            sender_clone
-                                .send(Msg::DisableIdleDetector)
-                                .expect("Could not send Msg::DisableIdleDetector");
-                        });
+                        disable_idle_detector_item.connect_activate(
+                            move |_| {
+                                sender_clone
+                                    .send(Msg::DisableIdleDetector)
+                                    .expect(
+                                    "Could not send Msg::DisableIdleDetector",
+                                );
+                            },
+                        );
                         menu.append(&disable_idle_detector_item);
                     }
                 }


### PR DESCRIPTION
This PR adds the following:

- A configuration option `idle_detection_enabled` for enabling the X idle timer.  It is set to `true` by default.  If you set it to `false`, then the X idle timer is ignored, so breaks will still occur even if you have stepped away from your computer.
- A switch to enable or disable the X idle timer when you right-click on the status bar icon.

Closes https://github.com/cdepillabout/break-time/issues/28.